### PR TITLE
Decoupled the specs formatting and running

### DIFF
--- a/mamba/cli.py
+++ b/mamba/cli.py
@@ -15,16 +15,20 @@ def main():
     settings = _settings_from_arguments(arguments)
     loader = Loader()
     formatter = formatters.DocumentationFormatter(settings)
-    runner = Runner(formatter)
+    runner = Runner()
+
+    specs = []
 
     for file_ in _collect_specs_from(arguments.specs):
         with loader.load_from_file(file_) as module:
-            runner.run(module)
+            runner.run(module.specs)
+            specs.extend(module.specs)
 
-    formatter.format_summary()
+    formatter.format(specs)
 
     if runner.has_failed_specs:
         sys.exit(1)
+
 
 def _parse_arguments():
     parser = argparse.ArgumentParser()

--- a/mamba/formatters.py
+++ b/mamba/formatters.py
@@ -23,12 +23,18 @@ class DocumentationFormatter(object):
     def specs_ran(self):
         return self.total_specs - self.skipped_specs
 
-    def format(self, item):
+    def format(self, items):
+        for item in items:
+            self._format_item(item)
+
+            self.total_seconds += item.elapsed_time.total_seconds()
+
+        self.format_summary()
+
+    def _format_item(self, item):
         puts()
         puts(colored.white(item.name))
         self._format_children(item)
-
-        self.total_seconds += item.elapsed_time.total_seconds()
 
     def _format_children(self, item):
         for spec_ in item.specs:

--- a/mamba/runner.py
+++ b/mamba/runner.py
@@ -1,12 +1,11 @@
 class Runner(object):
 
-    def __init__(self, formatter):
-        self.formatter = formatter
+    def __init__(self):
         self.has_failed_specs = False
 
-    def run(self, module):
-        for spec in module.specs:
+    def run(self, specs):
+        for spec in specs:
             spec.run()
-            self.formatter.format(spec)
+
             if spec.failed:
                 self.has_failed_specs = True


### PR DESCRIPTION
Hi!

I've decoupled the specs formatter and runner, so we can run the formatter after all the specs have been run. Now we should only call the formatter's `format` method in order to get the complete output, and it's easier to integrate new formatters in mamba.

Also related to #4.
