### PR TITLE
Adds example group failure reporting  fixes #15

### DIFF
--- a/mamba/example_group.py
+++ b/mamba/example_group.py
@@ -17,6 +17,7 @@ class ExampleGroup(object):
         self.context = context
         self.hooks = {'before_each': [], 'after_each': [], 'before_all': [], 'after_all': []}
         self._elapsed_time = timedelta(0)
+        self._error = None
 
     def run(self, reporter):
         self._start(reporter)
@@ -73,7 +74,10 @@ class ExampleGroup(object):
 
     def _finish(self, reporter):
         self._elapsed_time = datetime.utcnow() - self._begin
-        reporter.example_group_finished(self)
+        if self.error:
+            reporter.example_group_failed(self)
+        else:
+            reporter.example_group_finished(self)
 
     @property
     def elapsed_time(self):

--- a/mamba/formatters.py
+++ b/mamba/formatters.py
@@ -24,6 +24,9 @@ class Formatter(object):
     def example_group_started(self, example_group):
         pass
 
+    def example_group_failed(self, example_group):
+        pass
+
     def example_group_finished(self, example_group):
         pass
 
@@ -85,6 +88,10 @@ class DocumentationFormatter(Formatter):
 
     def example_group_started(self, example_group):
         self._format_example_group(example_group, colored.white)
+
+    def example_group_failed(self, example_group):
+        for example in example_group.examples:
+            self.example_failed(example)
 
     def example_group_finished(self, example_group):
         if example_group.parent is None:

--- a/mamba/reporter.py
+++ b/mamba/reporter.py
@@ -37,6 +37,11 @@ class Reporter(object):
     def example_group_started(self, example_group):
         self.notify('example_group_started', example_group)
 
+    def example_group_failed(self, example_group):
+        self.example_count += len(example_group.examples)
+        self.failed_examples.extend(example_group.examples)
+        self.notify('example_group_failed', example_group)
+
     def example_group_finished(self, example_group):
         self.notify('example_group_finished', example_group)
 

--- a/spec/reporter_spec.py
+++ b/spec/reporter_spec.py
@@ -12,6 +12,7 @@ with describe(reporter.Reporter) as _:
     @before.each
     def create_reporter_and_attach_formatter():
         _.example = an_example(_)
+        _.example_group = an_example_group()
         _.formatter = Spy(formatters.Formatter)
         _.reporter = reporter.Reporter(_.formatter)
         _.reporter.start()
@@ -41,6 +42,11 @@ with describe(reporter.Reporter) as _:
 
         expect(_.reporter.failed_count).to.be.equal(1)
 
+    def it_increases_example_counter_when_example_group_failed():
+        _.reporter.example_group_failed(_.example_group)
+
+        expect(_.reporter.example_count).to.be.equal(len(_.example_group.examples))
+
     def it_adds_failed_example_when_example_failed():
         _.reporter.example_failed(_.example)
 
@@ -65,6 +71,11 @@ with describe(reporter.Reporter) as _:
             _.reporter.example_group_started(_.example_group)
 
             assert_that(_.formatter.example_group_started, called().with_args(_.example_group))
+
+        def it_notifies_event_example_group_failed_to_listeners():
+            _.reporter.example_group_failed(_.example_group)
+
+            assert_that(_.formatter.example_group_failed, called().with_args(_.example_group))
 
         def it_notifies_event_example_group_finished_to_listeners():
             _.reporter.example_group_finished(_.example_group)


### PR DESCRIPTION
When an exception happens to be raised within a `(before|after).all` function, forcing an entire example group to fail, all failed/not-run examples within the group are ignored by the reporter.
Yet the process stills returns 1, and therefore marks the build as a failure.

Adds `Reporter.example_group_failed` and `Formatter.example_group_failed` which handle this situation, by reporting examples within the failed group as failed, bloody red allover.

This ensures that the run won't cheerfuly fail all in green, while displaying "0 specs ran".
It should fix https://github.com/nestorsalceda/mamba/issues/15

``` python
from mamba import describe, before


with describe('weird mamba behaviour'):
    @before.all
    def setup():
        raise Exception()

    def should_not_pass():
        pass
```

now outputs 

```
$ mamba test_spec.py
weird mamba behaviour
  ✗ should not pass

1 examples failed of 1 ran in 0.0187 seconds

Failures:

  1) weird mamba behaviour should not pass
     Failure/Error: 

     Traceback:
     File "/home/user/mamba/mamba/example_group.py", line 61, in _run_inner_examples
         self.run_hook('before_all')
     File "/home/user/mamba/mamba/example_group.py", line 69, in run_hook
         registered()
     File "test_spec.py", line 7, in setup
         raise Exception()
$ echo $?
1
```

instead of 

```
$mamba test_spec.py
weird mamba behaviour

0 examples ran in 0.0180 seconds
$ echo $?
1
```
