### PR TITLE
Fix example execution in python3

### DIFF
--- a/mamba/example.py
+++ b/mamba/example.py
@@ -34,7 +34,9 @@ class Example(object):
         self.run_hook('before_each')
         if hasattr(self.test, 'im_func'):
             self.test.im_func(self.parent.execution_context)
-            self.was_run = True
+        else:
+            self.test(self.parent.execution_context)
+        self.was_run = True
         self.run_hook('after_each')
 
     def run_hook(self, hook):


### PR DESCRIPTION
I found that examples (neither hooks) were not being executed in python 3.

I made a little change to report all examples that have not been executed as pending (and not only `PendingExample` subclasses) so we can see than in fact examples are not being executed.

I opened this PR to watch travis results while I'm working on a patch.
