### PR TITLE
Use .coveragerc file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+source = ./mamba
+omit = ./mamba/__init__.py, ./mamba/infrastructure/__init__.py
+branch = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ python:
 install: "pip install -r requirements.txt -r requirements-dev.txt"
 before_script: python setup.py develop
 script: mamba --enable-coverage
-after_success: 'coverage report --include="mamba/*","spec/*"'
+after_success: 'coverage report'

--- a/circle.yml
+++ b/circle.yml
@@ -6,5 +6,4 @@ test:
   override:
     - mamba --enable-coverage
   post:
-    - 'coverage report --include="mamba/*","spec/*"'
-
+    - 'coverage report'


### PR DESCRIPTION
Using a `.coveragerc` is cleaner, as you can specify which files to measure coverage on, instead of running it in the whole project and then filter in `coverage report`.

This includes a very simple `.coveragerc` template, but I guess not all files from `./mamba` should be included. However, in my experience, spec files should not be included in coverage measurement, as they are obviously going to have 100% coverage (the test code does run, or else you have a bigger problem), which would probably skew the coverage results upwards. Further, spec files are typically not part of the code you're acutally interested in covering. For these reasons, I didn't include it in the `.coveragerc`.

This `.coveragerc` file also instructs `coverage` to measure branch coverage, which is disabled by default.