### PR TITLE
Run example groups and examples in natural order (not alphanumeric)

### DIFF
--- a/mamba/example.py
+++ b/mamba/example.py
@@ -73,7 +73,7 @@ class Example(object):
 
     @property
     def name(self):
-        return self.test.__name__
+        return self.test.__name__[10:]
 
     @property
     def failed(self):

--- a/mamba/formatters.py
+++ b/mamba/formatters.py
@@ -68,7 +68,10 @@ class DocumentationFormatter(Formatter):
         puts('  ' * self._depth(example) + symbol + ' ' + self._format_example_name(example) + self._format_slow_test(example))
 
     def _format_example_name(self, example):
-        return example.name.replace('_', ' ')
+        name = example.name
+        if name[8:10] == '__' and name[:8].isdigit():
+            name = name[10:]
+        return name.replace('_', ' ')
 
     def _format_slow_test(self, example):
         seconds = total_seconds(example.elapsed_time)

--- a/mamba/loader.py
+++ b/mamba/loader.py
@@ -33,7 +33,11 @@ class Loader(object):
         return ExampleGroup(self._subject(klass), execution_context=execution_context)
 
     def _subject(self, example_group):
-        return getattr(example_group, '_subject_class', example_group.__name__.replace('__description', '').replace('__pending', ''))
+        subject = getattr(example_group, '_subject_class', example_group.__name__.replace('__description', '').replace('__pending', ''))
+        if isinstance(subject, str):
+            return subject[10:]
+        else:
+            return subject
 
     def _add_hooks_examples_and_nested_example_groups_to(self, klass, example_group):
         self._load_hooks(klass, example_group)
@@ -65,10 +69,10 @@ class Loader(object):
         return inspect.getmembers(klass, inspect.isfunction if is_python3() else inspect.ismethod)
 
     def _is_example(self, method):
-        return method.__name__.startswith('it') or self._is_pending_example(method)
+        return method.__name__[10:].startswith('it') or self._is_pending_example(method)
 
     def _is_pending_example(self, example):
-        return example.__name__.startswith('_it')
+        return example.__name__[10:].startswith('_it')
 
     def _is_pending_example_group(self, example_group):
         return isinstance(example_group, PendingExampleGroup)

--- a/mamba/nodetransformers.py
+++ b/mamba/nodetransformers.py
@@ -65,7 +65,7 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
         if name in self.PENDING_EXAMPLE_GROUPS:
             description_name += '__pending'
 
-        description_name = '{:08d}__{}__description'.format(self.sequence, description_name)
+        description_name = '{0:08d}__{1}__description'.format(self.sequence, description_name)
         self.sequence += 1
 
         return description_name
@@ -74,7 +74,7 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
         return not isinstance(self._context_expr_for(node).args[0], ast.Str)
 
     def _transform_to_example(self, node, name):
-        example_name = '{:08d}__{} {}'.format(self.sequence, name, self._context_expr_for(node).args[0].s)
+        example_name = '{0:08d}__{1} {2}'.format(self.sequence, name, self._context_expr_for(node).args[0].s)
         self.sequence += 1
         return ast.copy_location(
             ast.FunctionDef(

--- a/mamba/nodetransformers.py
+++ b/mamba/nodetransformers.py
@@ -7,6 +7,8 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
     EXAMPLES = ('it', '_it')
     HOOKS = ('before', 'after')
 
+    sequence = 1
+
     def visit_With(self, node):
         super(TransformToSpecsNodeTransformer, self).generic_visit(node)
 
@@ -63,7 +65,8 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
         if name in self.PENDING_EXAMPLE_GROUPS:
             description_name += '__pending'
 
-        description_name += '__description'
+        description_name = '{:08d}__{}__description'.format(self.sequence, description_name)
+        self.sequence += 1
 
         return description_name
 
@@ -71,10 +74,11 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
         return not isinstance(self._context_expr_for(node).args[0], ast.Str)
 
     def _transform_to_example(self, node, name):
-        example = self._context_expr_for(node).args[0].s
+        example_name = '{:08d}__{} {}'.format(self.sequence, name, self._context_expr_for(node).args[0].s)
+        self.sequence += 1
         return ast.copy_location(
             ast.FunctionDef(
-                name=name + ' ' + example,
+                name=example_name,
                 args=self._generate_self(),
                 body=node.body,
                 decorator_list=[]


### PR DESCRIPTION
This is a simple spec:

```python
with describe("e 1."):
    with context("l 1.1."):
        with it("k 1.1.1."):
            pass
        with it("g 1.1.2."):
            pass
        with it("d 1.1.3."):
            pass
    with context("n 1.2."):
        with it("i 1.2.1."):
            pass
        with it("a 1.2.2."):
            pass
    with context("c 1.3."):
        with it("q 1.3.1."):
            pass
with describe("m 2."):
    with context("j 2.1."):
        with it("o 2.1.1."):
            pass
        with it("b 2.1.2."):
            pass
    with context("p 2.2."):
        with it("h 2.2.1."):
            pass
        with it("f 2.2.2."):
            pass
```

Current mamba runs it in alphanumeric order:

```
e 1.
  c 1.3.
    ✓ it q 1.3.1.
  l 1.1.
    ✓ it d 1.1.3.
    ✓ it g 1.1.2.
    ✓ it k 1.1.1.
  n 1.2.
    ✓ it a 1.2.2.
    ✓ it i 1.2.1.

m 2.
  j 2.1.
    ✓ it b 2.1.2.
    ✓ it o 2.1.1.
  p 2.2.
    ✓ it f 2.2.2.
    ✓ it h 2.2.1.

10 examples ran in 0.0124 seconds
```

After the patch it is ran in natural order (from top to bottom):

```
e 1.
  l 1.1.
    ✓ it k 1.1.1.
    ✓ it g 1.1.2.
    ✓ it d 1.1.3.
  n 1.2.
    ✓ it i 1.2.1.
    ✓ it a 1.2.2.
  c 1.3.
    ✓ it q 1.3.1.

m 2.
  j 2.1.
    ✓ it o 2.1.1.
    ✓ it b 2.1.2.
  p 2.2.
    ✓ it h 2.2.1.
    ✓ it f 2.2.2.

10 examples ran in 0.0131 seconds
```

The trick is that some sequence number is added to each class and function name and removed when it is printed out in report.
