### PR TITLE
Declare minimal dependencies in setup.py install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,11 @@ setup(name='mamba',
       packages=find_packages(exclude=['ez_setup', 'examples', 'spec', 'spec.*']),
       include_package_data=True,
       zip_safe=False,
-      install_requires=[line for line in open('requirements.txt')],
+      install_requires=[
+          'clint',
+          'coverage',
+          'watchdog'
+      ],
       entry_points={
           'console_scripts': [
               'mamba = mamba.cli:main'


### PR DESCRIPTION
### The issue:

Currently setup.py is reading the dependencies from `requirements.txt`, which has pinned versions, and therefore is forcing users  to downgrade/upgrade to those versions when doing `pip install mamba`.

### The solution:

It's better to declare very loose versions in `setup.py`, if any, to avoid messing with user's system -- a small duplication is OK here, IMO.

If you don't want to duplicate, remove the pinned versions from `requirements.txt`.

Personally, I'd rather to have the duplication, though, because for me they're two very different things: install_requires is about the very minimal dependencies needed for users, requirements.txt is about making development and testing environments easily repeatable.