### PR TITLE
Settings: no need to use properties for the moment, so remove them

### DIFF
--- a/mamba/settings.py
+++ b/mamba/settings.py
@@ -2,63 +2,10 @@
 
 
 class Settings(object):
-
     def __init__(self):
-        self._slow_test_threshold = .075
-        self._enable_code_coverage = False
-        self._code_coverage_file = '.coverage'
-        self._enable_file_watcher = False
-        self._format = 'documentation'
-        self._no_color = False
-
-    @property
-    def format(self):
-        return self._format
-
-    @format.setter
-    def format(self, value):
-        self._format = value
-
-    @property
-    def slow_test_threshold(self):
-        return self._slow_test_threshold
-
-    @slow_test_threshold.setter
-    def slow_test_threshold(self, value):
-        self._slow_test_threshold = value
-
-    @property
-    def enable_code_coverage(self):
-        return self._enable_code_coverage
-
-    @property
-    def no_color(self):
-        return self._no_color
-
-    @no_color.setter
-    def no_color(self, value):
-        self._no_color = value
-
-    @enable_code_coverage.setter
-    def enable_code_coverage(self, value):
-        self._enable_code_coverage = value
-
-    @property
-    def code_coverage_file(self):
-        return self._code_coverage_file
-
-    @code_coverage_file.setter
-    def code_coverage_file(self, value):
-        self._code_coverage_file = value
-
-    @format.setter
-    def format(self, value):
-        self._format = value
-
-    @property
-    def enable_file_watcher(self):
-        return self._enable_file_watcher
-
-    @enable_file_watcher.setter
-    def enable_file_watcher(self, value):
-        self._enable_file_watcher = value
+        self.slow_test_threshold = .075
+        self.enable_code_coverage = False
+        self.code_coverage_file = '.coverage'
+        self.enable_file_watcher = False
+        self.format = 'documentation'
+        self.no_color = False


### PR DESCRIPTION
There is no additional logic which needs to be executed on property access or change. And all members of Settings are being accessed after creation, so they can be considered public for all purposes. Hence we don't need the property mechanism, and it can be introduced without breaking anything whenever it's needed.