### PR TITLE
Properly measure mamba's own coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ python:
   - "pypy"
 install: "pip install -r requirements.txt -r requirements-dev.txt"
 before_script: python setup.py develop
-script: mamba --enable-coverage
+script: coverage run mamba/cli.py
 after_success: 'coverage report'

--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,6 @@ dependencies:
     - python setup.py develop
 test:
   override:
-    - mamba --enable-coverage
+    - coverage run mamba/cli.py
   post:
     - 'coverage report'


### PR DESCRIPTION
Using mamba's built-in support for coverage to compute mamba's own coverage
doesn't provide correct statistics, because by the time the CodeCoverageRunner
is set up, half the mamba code has already run.

This runs mamba using the `coverage run` command-line tool, which allows
`coverage` to hook in early in the import system and hence provide a correct
measurement.