### PR TITLE
Fixes issue #96 - after.each only executes if examples pass. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 build
 dist
 .coverage
+.idea

--- a/mamba/example.py
+++ b/mamba/example.py
@@ -27,8 +27,7 @@ class Example(runnable.Runnable):
         if self.error is None:
             self._execute_test(execution_context)
 
-        if self.error is None:
-            self.parent.execute_hook('after_each', execution_context)
+        self.parent.execute_hook('after_each', execution_context)
 
         self.was_run = True
         self._finish(reporter)

--- a/spec/errors_in_hooks_spec.py
+++ b/spec/errors_in_hooks_spec.py
@@ -1,5 +1,5 @@
 from mamba import description, before, it, context
-from expects import expect, be_none, be_a, be_true
+from expects import expect, be_none, be_a, be_true, be_false
 from doublex import Spy
 
 from mamba import reporter, runnable
@@ -75,13 +75,13 @@ with description('Errors in hooks') as self:
             expect(self.example.error).not_to(be_none)
 
         with context('when an error happened in the example'):
-            with it('does not execute after_each hook'):
+            with it('still executes after_each hook'):
                 self.example = a_failing_example()
                 self.example_group.append(self.example)
 
                 self.example_group.execute(self.reporter, runnable.ExecutionContext())
 
-                expect(isinstance(self.example.error.exception, ValueError)).to(be_true)
+                expect(isinstance(self.example.error.exception, ValueError)).to(be_false)
 
     with context('when an error was raised in an after.all hook'):
         with before.each:


### PR DESCRIPTION
There was an if statement that checked for errors and only ran code in after.each if there were none. Removed this if check.