### PR TITLE
Example Collector: Use class/function attributes instead of encoding information in name

### DIFF
--- a/mamba/example.py
+++ b/mamba/example.py
@@ -55,7 +55,7 @@ class Example(runnable.Runnable):
 
     @property
     def name(self):
-        return self.test.__name__[10:].replace('--', '').replace('fit', 'it')
+        return self.test._example_name
 
 
 class PendingExample(Example):

--- a/mamba/formatters.py
+++ b/mamba/formatters.py
@@ -63,13 +63,7 @@ class DocumentationFormatter(Formatter):
         self._format_example(self._color('yellow', '✗'), example)
 
     def _format_example(self, symbol, example):
-        puts('  ' * self._depth(example) + symbol + ' ' + self._format_example_name(example) + self._format_slow_test(example))
-
-    def _format_example_name(self, example):
-        name = example.name
-        if name[8:10] == '__' and name[:8].isdigit():
-            name = name[10:]
-        return name.replace('_', ' ')
+        puts('  ' * self._depth(example) + symbol + ' ' + example.name + self._format_slow_test(example))
 
     def _format_slow_test(self, example):
         seconds = example.elapsed_time.total_seconds()
@@ -127,11 +121,11 @@ class DocumentationFormatter(Formatter):
                     puts()
 
     def _format_full_example_name(self, example):
-        result = [self._format_example_name(example)]
+        result = [example.name]
 
         current = example
         while current.parent:
-            result.append(self._format_example_name(current.parent))
+            result.append(current.parent.name)
             current = current.parent
 
         result.reverse()

--- a/mamba/loader.py
+++ b/mamba/loader.py
@@ -28,7 +28,7 @@ class Loader(object):
 
     def _create_example_group(self, klass):
         name = self._description(klass)
-        tags = self._tags_for(name)
+        tags = self._tags_for(klass)
 
         if '__pending' in klass.__name__:
             return PendingExampleGroup(name, tags=tags)
@@ -55,7 +55,7 @@ class Loader(object):
 
     def _load_examples(self, klass, example_group):
         for example in self._examples_in(klass):
-            tags = self._tags_for(example.__name__)
+            tags = self._tags_for(example)
             if self._is_pending_example(example) or self._is_pending_example_group(example_group):
                 example_group.append(PendingExample(example, tags=tags))
             else:
@@ -64,8 +64,8 @@ class Loader(object):
     def _examples_in(self, example_group):
         return [method for name, method in self._methods_for(example_group) if self._is_example(method)]
 
-    def _tags_for(self, name):
-        tags = name.split('--')[1]
+    def _tags_for(self, example):
+        tags = getattr(example, '_tags', '')
         if not tags:
             return None
         return tags.split(',')

--- a/mamba/loader.py
+++ b/mamba/loader.py
@@ -28,7 +28,7 @@ class Loader(object):
 
     def _create_example_group(self, klass):
         name = self._description(klass)
-        tags = self._tags_for(klass)
+        tags = klass._tags
 
         if klass._pending:
             return PendingExampleGroup(name, tags=tags)
@@ -55,7 +55,7 @@ class Loader(object):
 
     def _load_examples(self, klass, example_group):
         for example in self._examples_in(klass):
-            tags = self._tags_for(example)
+            tags = example._tags
             if self._is_pending_example(example) or self._is_pending_example_group(example_group):
                 example_group.append(PendingExample(example, tags=tags))
             else:
@@ -63,12 +63,6 @@ class Loader(object):
 
     def _examples_in(self, example_group):
         return [method for name, method in self._methods_for(example_group) if self._is_example(method)]
-
-    def _tags_for(self, example):
-        tags = getattr(example, '_tags', '')
-        if not tags:
-            return None
-        return tags.split(',')
 
     def _methods_for(self, klass):
         return inspect.getmembers(klass, inspect.isfunction if is_python3() else inspect.ismethod)

--- a/mamba/loader.py
+++ b/mamba/loader.py
@@ -30,12 +30,12 @@ class Loader(object):
         name = self._description(klass)
         tags = self._tags_for(klass)
 
-        if '__pending' in klass.__name__:
+        if klass._pending:
             return PendingExampleGroup(name, tags=tags)
         return ExampleGroup(name, tags=tags)
 
     def _description(self, example_group):
-        return example_group.__name__.replace('__description', '').replace('__pending', '')[10:]
+        return example_group.__name__.replace('__description', '')[10:]
 
     def _add_hooks_examples_and_nested_example_groups_to(self, klass, example_group):
         self._load_hooks(klass, example_group)
@@ -80,7 +80,7 @@ class Loader(object):
         return example.__name__[10:].startswith('fit')
 
     def _is_pending_example(self, example):
-        return example.__name__[10:].startswith('_it')
+        return example._pending
 
     def _is_pending_example_group(self, example_group):
         return isinstance(example_group, PendingExampleGroup)

--- a/mamba/loader.py
+++ b/mamba/loader.py
@@ -71,7 +71,7 @@ class Loader(object):
         return getattr(method, '_example', False)
 
     def _is_focused_example(self, example):
-        return example.__name__[10:].startswith('fit')
+        return 'focus' in example._tags
 
     def _is_pending_example(self, example):
         return example._pending

--- a/mamba/loader.py
+++ b/mamba/loader.py
@@ -74,9 +74,7 @@ class Loader(object):
         return inspect.getmembers(klass, inspect.isfunction if is_python3() else inspect.ismethod)
 
     def _is_example(self, method):
-        return method.__name__[10:].startswith('it') \
-            or self._is_focused_example(method) \
-            or self._is_pending_example(method)
+        return getattr(method, '_example', False)
 
     def _is_focused_example(self, example):
         return example.__name__[10:].startswith('fit')

--- a/mamba/loader.py
+++ b/mamba/loader.py
@@ -21,10 +21,10 @@ class Loader(object):
         return loaded
 
     def _example_groups_for(self, module):
-        return [klass for name, klass in inspect.getmembers(module, inspect.isclass) if self._is_example_group(name)]
+        return [klass for name, klass in inspect.getmembers(module, inspect.isclass) if self._is_example_group(klass)]
 
-    def _is_example_group(self, class_name):
-        return class_name.endswith('__description')
+    def _is_example_group(self, klass):
+        return getattr(klass, '_example_group', False)
 
     def _create_example_group(self, klass):
         name = self._description(klass)
@@ -35,7 +35,7 @@ class Loader(object):
         return ExampleGroup(name, tags=tags)
 
     def _description(self, example_group):
-        return example_group.__name__.replace('__description', '')[10:]
+        return example_group.__name__[10:]
 
     def _add_hooks_examples_and_nested_example_groups_to(self, klass, example_group):
         self._load_hooks(klass, example_group)

--- a/mamba/loader.py
+++ b/mamba/loader.py
@@ -27,15 +27,12 @@ class Loader(object):
         return getattr(klass, '_example_group', False)
 
     def _create_example_group(self, klass):
-        name = self._description(klass)
+        name = klass._example_name
         tags = klass._tags
 
         if klass._pending:
             return PendingExampleGroup(name, tags=tags)
         return ExampleGroup(name, tags=tags)
-
-    def _description(self, example_group):
-        return example_group.__name__[10:]
 
     def _add_hooks_examples_and_nested_example_groups_to(self, klass, example_group):
         self._load_hooks(klass, example_group)
@@ -82,7 +79,7 @@ class Loader(object):
     def _load_nested_example_groups(self, klass, example_group):
         for nested in self._example_groups_for(klass):
             if isinstance(example_group, PendingExampleGroup):
-                nested_example_group = PendingExampleGroup(self._description(nested))
+                nested_example_group = PendingExampleGroup(nested._example_name)
             else:
                 nested_example_group = self._create_example_group(nested)
 

--- a/mamba/nodetransformers.py
+++ b/mamba/nodetransformers.py
@@ -105,7 +105,7 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
         if len(context_expr.args) > 1:
             tags.extend([arg.s for arg in context_expr.args[1:]])
 
-        return ','.join(tags)
+        return tags
 
     def _transform_to_example(self, node, name):
         context_expr = self._context_expr_for(node)
@@ -147,16 +147,19 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
         )
 
     def _set_attribute(self, attr, value):
-        if isinstance(value, bool):
-            val = ast.NameConstant(value=value is True)
-        else:
-            val = ast.Str(str(value))
-
         return ast.Call(
             func=ast.Name(id='add_attribute_decorator', ctx=ast.Load()),
-            args=[ast.Str(attr), val],
+            args=[ast.Str(attr), self._convert_value(value)],
             keywords=[]
         )
+
+    def _convert_value(self, value):
+        if isinstance(value, bool):
+            return ast.NameConstant(value=value is True)
+        elif isinstance(value, list):
+            return ast.List(elts=list(map(self._convert_value, value)), ctx=ast.Load())
+        else:
+            return ast.Str(str(value))
 
 
 

--- a/mamba/nodetransformers.py
+++ b/mamba/nodetransformers.py
@@ -149,7 +149,7 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
 
     def _convert_value(self, value):
         if isinstance(value, bool):
-            return ast.NameConstant(value=value is True)
+            return ast.Str(str(value) if value else '') 
         elif isinstance(value, list):
             return ast.List(elts=list(map(self._convert_value, value)), ctx=ast.Load())
         else:

--- a/mamba/nodetransformers.py
+++ b/mamba/nodetransformers.py
@@ -145,9 +145,14 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
         )
 
     def _set_attribute(self, attr, value):
+        if isinstance(value, bool):
+            val = ast.NameConstant(value=value is True)
+        else:
+            val = ast.Str(str(value))
+
         return ast.Call(
             func=ast.Name(id='add_attribute_decorator', ctx=ast.Load()),
-            args=[ast.Str(attr), ast.Str(value)],
+            args=[ast.Str(attr), val],
             keywords=[]
         )
 

--- a/mamba/nodetransformers.py
+++ b/mamba/nodetransformers.py
@@ -25,7 +25,11 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
 
         super(TransformToSpecsNodeTransformer, self).generic_visit(node)
 
-        node.body.insert(0, ast.ImportFrom(module='mamba.nodetransformers', names=[ast.alias(name='add_attribute_decorator')]))
+        node.body.insert(0, ast.ImportFrom(
+            module='mamba.nodetransformers',
+            names=[ast.alias(name='add_attribute_decorator')],
+            level=0
+        ))
         node.body.append(ast.Assign(
             targets=[ast.Name(id='__mamba_has_focused_examples', ctx=ast.Store())],
             value=ast.Name(id=str(self.has_focused_examples), ctx=ast.Load())),

--- a/mamba/nodetransformers.py
+++ b/mamba/nodetransformers.py
@@ -123,6 +123,7 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
                 args=self._generate_argument('self'),
                 body=node.body,
                 decorator_list=[
+                    self._set_attribute('_example', True),
                     self._set_attribute('_tags', self._tags_from(context_expr, name))
                 ]
             ),

--- a/mamba/nodetransformers.py
+++ b/mamba/nodetransformers.py
@@ -70,7 +70,9 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
                 bases=[],
                 keywords=[],
                 body=node.body,
-                decorator_list=[]
+                decorator_list=[
+                    self._set_attribute('_tags', self._tags_from(self._context_expr_for(node), name))
+                ]
             ),
             node
         )
@@ -87,10 +89,9 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
         if name in self.PENDING_EXAMPLE_GROUPS:
             description_name += '__pending'
 
-        description_name = '{0:08d}__{1}--{2}__description'.format(
+        description_name = '{0:08d}__{1}__description'.format(
             self.sequence,
             description_name,
-            self._tags_from(context_expr, name)
         )
 
         self.sequence += 1
@@ -109,11 +110,10 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
     def _transform_to_example(self, node, name):
         context_expr = self._context_expr_for(node)
 
-        example_name = '{0:08d}__{1} {2}--{3}'.format(
+        example_name = '{0:08d}__{1} {2}'.format(
             self.sequence,
             name,
-            context_expr.args[0].s,
-            self._tags_from(context_expr, name)
+            context_expr.args[0].s
         )
         self.sequence += 1
 
@@ -122,7 +122,9 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
                 name=example_name,
                 args=self._generate_argument('self'),
                 body=node.body,
-                decorator_list=[]
+                decorator_list=[
+                    self._set_attribute('_tags', self._tags_from(context_expr, name))
+                ]
             ),
             node
         )

--- a/mamba/nodetransformers.py
+++ b/mamba/nodetransformers.py
@@ -112,22 +112,22 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
         return ast.copy_location(
             ast.FunctionDef(
                 name=example_name,
-                args=self._generate_self(),
+                args=self._generate_argument('self'),
                 body=node.body,
                 decorator_list=[]
             ),
             node
         )
 
-    def _generate_self(self):
-        return ast.arguments(args=[ast.Name(id='self', ctx=ast.Param())], vararg=None, kwarg=None, defaults=[])
+    def _generate_argument(self, name):
+        return ast.arguments(args=[ast.Name(id=name, ctx=ast.Param())], vararg=None, kwarg=None, defaults=[])
 
     def _transform_to_hook(self, node, name):
         when = self._context_expr_for(node).attr
         return ast.copy_location(
             ast.FunctionDef(
                 name=name + '_' + when,
-                args=self._generate_self(),
+                args=self._generate_argument('self'),
                 body=node.body,
                 decorator_list=[]
             ),
@@ -140,13 +140,12 @@ class TransformToSpecsPython3NodeTransformer(TransformToSpecsNodeTransformer):
     def _context_expr_for(self, node):
         return node.items[0].context_expr
 
-    def _generate_self(self):
+    def _generate_argument(self, name):
         return ast.arguments(
-            args=[ast.arg(arg='self', annotation=None)],
+            args=[ast.arg(arg=name, annotation=None)],
             vararg=None,
             kwonlyargs=[],
             kw_defaults=[],
             kwarg=None,
             defaults=[]
         )
-

--- a/mamba/nodetransformers.py
+++ b/mamba/nodetransformers.py
@@ -13,7 +13,8 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
     FOCUSED_EXAMPLE_GROUPS = ('fdescription', 'fcontext', 'fdescribe')
     EXAMPLE_GROUPS = ('description', 'context', 'describe') + PENDING_EXAMPLE_GROUPS + FOCUSED_EXAMPLE_GROUPS
     FOCUSED_EXAMPLE = ('fit', )
-    EXAMPLES = ('it', '_it') + FOCUSED_EXAMPLE
+    PENDING_EXAMPLE = ('_it', )
+    EXAMPLES = ('it',) + PENDING_EXAMPLE + FOCUSED_EXAMPLE
     FOCUSED = FOCUSED_EXAMPLE_GROUPS + FOCUSED_EXAMPLE
     HOOKS = ('before', 'after')
 
@@ -71,7 +72,8 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
                 keywords=[],
                 body=node.body,
                 decorator_list=[
-                    self._set_attribute('_tags', self._tags_from(self._context_expr_for(node), name))
+                    self._set_attribute('_tags', self._tags_from(self._context_expr_for(node), name)),
+                    self._set_attribute('_pending', name in self.PENDING_EXAMPLE_GROUPS)
                 ]
             ),
             node
@@ -85,9 +87,6 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
             description_name = context_expr.args[0].attr
         else:
             description_name = context_expr.args[0].id
-
-        if name in self.PENDING_EXAMPLE_GROUPS:
-            description_name += '__pending'
 
         description_name = '{0:08d}__{1}__description'.format(
             self.sequence,
@@ -124,7 +123,8 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
                 body=node.body,
                 decorator_list=[
                     self._set_attribute('_example', True),
-                    self._set_attribute('_tags', self._tags_from(context_expr, name))
+                    self._set_attribute('_tags', self._tags_from(context_expr, name)),
+                    self._set_attribute('_pending', name in self.PENDING_EXAMPLE)
                 ]
             ),
             node

--- a/mamba/nodetransformers.py
+++ b/mamba/nodetransformers.py
@@ -153,7 +153,7 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
 
     def _convert_value(self, value):
         if isinstance(value, bool):
-            return ast.Str(str(value) if value else '') 
+            return ast.Str(str(value) if value else '')
         elif isinstance(value, list):
             return ast.List(elts=list(map(self._convert_value, value)), ctx=ast.Load())
         else:

--- a/mamba/nodetransformers.py
+++ b/mamba/nodetransformers.py
@@ -72,6 +72,7 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
                 keywords=[],
                 body=node.body,
                 decorator_list=[
+                    self._set_attribute('_example_group', True),
                     self._set_attribute('_tags', self._tags_from(self._context_expr_for(node), name)),
                     self._set_attribute('_pending', name in self.PENDING_EXAMPLE_GROUPS)
                 ]
@@ -88,7 +89,7 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
         else:
             description_name = context_expr.args[0].id
 
-        description_name = '{0:08d}__{1}__description'.format(
+        description_name = '{0:08d}__{1}'.format(
             self.sequence,
             description_name,
         )


### PR DESCRIPTION
I added a little decorator that can be used by the node transformer to add arbitrary attributes to the generated functions and classes.

Using this decorator I moved all the relevant information about the generated examples and groups into attributes of the class/function instead of encoding it in the name.

The introduced attributes are:
* `_example`: True when the method is an example
* `_example_group`: True when the class is an example group
* `_pending`: True when the example or group is pending
* `_tags`: List of tags
* `_example_name`: Description of the example/group, which can now directly be used by the formatter without first having to remove underbars etc.