### PR TITLE
Shared contexts

### DIFF
--- a/mamba/__init__.py
+++ b/mamba/__init__.py
@@ -53,6 +53,10 @@ def shared_context(message):
     pass
 
 
+def included_context(message):
+    pass
+
+
 def before():
     pass
 

--- a/mamba/__init__.py
+++ b/mamba/__init__.py
@@ -49,6 +49,10 @@ def fcontext(message):
     pass
 
 
+def shared_context(message):
+    pass
+
+
 def before():
     pass
 

--- a/mamba/example_group.py
+++ b/mamba/example_group.py
@@ -117,4 +117,5 @@ class PendingExampleGroup(ExampleGroup):
 
 
 class SharedExampleGroup(ExampleGroup):
-    pass
+    def execute(self, reporter, execution_context, tags=None):
+        pass

--- a/mamba/example_group.py
+++ b/mamba/example_group.py
@@ -114,3 +114,7 @@ class PendingExampleGroup(ExampleGroup):
             raise TypeError('A pending example or example group expected')
 
         super(PendingExampleGroup, self).append(example)
+
+
+class SharedExampleGroup(ExampleGroup):
+    pass

--- a/mamba/loader.py
+++ b/mamba/loader.py
@@ -2,7 +2,7 @@
 
 import inspect
 
-from mamba.example_group import ExampleGroup, PendingExampleGroup
+from mamba.example_group import ExampleGroup, PendingExampleGroup, SharedExampleGroup
 from mamba.example import Example, PendingExample
 from mamba.infrastructure import is_python3
 
@@ -32,6 +32,8 @@ class Loader(object):
 
         if klass._pending:
             return PendingExampleGroup(name, tags=tags)
+        elif klass._shared:
+            return SharedExampleGroup(name, tags=tags)
         return ExampleGroup(name, tags=tags)
 
     def _add_hooks_examples_and_nested_example_groups_to(self, klass, example_group):

--- a/mamba/nodetransformers.py
+++ b/mamba/nodetransformers.py
@@ -11,7 +11,8 @@ def add_attribute_decorator(attr, value):
 class TransformToSpecsNodeTransformer(ast.NodeTransformer):
     PENDING_EXAMPLE_GROUPS = ('_description', '_context', '_describe')
     FOCUSED_EXAMPLE_GROUPS = ('fdescription', 'fcontext', 'fdescribe')
-    EXAMPLE_GROUPS = ('description', 'context', 'describe') + PENDING_EXAMPLE_GROUPS + FOCUSED_EXAMPLE_GROUPS
+    SHARED_EXAMPLE_GROUPS = ('shared_context', )
+    EXAMPLE_GROUPS = ('description', 'context', 'describe') + PENDING_EXAMPLE_GROUPS + FOCUSED_EXAMPLE_GROUPS + SHARED_EXAMPLE_GROUPS
     FOCUSED_EXAMPLE = ('fit', )
     PENDING_EXAMPLE = ('_it', )
     EXAMPLES = ('it',) + PENDING_EXAMPLE + FOCUSED_EXAMPLE
@@ -81,7 +82,8 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
                     self._set_attribute('_example_group', True),
                     self._set_attribute('_example_name', example_name),
                     self._set_attribute('_tags', self._tags_from(context_expr, name)),
-                    self._set_attribute('_pending', name in self.PENDING_EXAMPLE_GROUPS)
+                    self._set_attribute('_pending', name in self.PENDING_EXAMPLE_GROUPS),
+                    self._set_attribute('_shared', name in self.SHARED_EXAMPLE_GROUPS)
                 ]
             ),
             node

--- a/mamba/nodetransformers.py
+++ b/mamba/nodetransformers.py
@@ -24,6 +24,7 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
 
     def visit_Module(self, node):
         self.has_focused_examples = False
+        self.shared_contexts = {}
 
         super(TransformToSpecsNodeTransformer, self).generic_visit(node)
 
@@ -75,6 +76,10 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
     def _transform_to_example_group(self, node, name):
         context_expr = self._context_expr_for(node)
         example_name = self._human_readable_context_expr(context_expr)
+
+        if name in self.SHARED_EXAMPLE_GROUPS:
+            self.shared_contexts[example_name] = node.body
+
         return ast.copy_location(
             ast.ClassDef(
                 name=self._prefix_with_sequence(example_name),
@@ -158,7 +163,7 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
                 name=self._prefix_with_sequence(example_name),
                 bases=[],
                 keywords=[],
-                body=node.body,
+                body=self.shared_contexts[example_name] + node.body,
                 decorator_list=[
                     self._set_attribute('_example_group', True),
                     self._set_attribute('_example_name', example_name),

--- a/mamba/nodetransformers.py
+++ b/mamba/nodetransformers.py
@@ -12,6 +12,7 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
     PENDING_EXAMPLE_GROUPS = ('_description', '_context', '_describe')
     FOCUSED_EXAMPLE_GROUPS = ('fdescription', 'fcontext', 'fdescribe')
     SHARED_EXAMPLE_GROUPS = ('shared_context', )
+    INCLUDED_EXAMPLE_GROUPS = ('included_context', )
     EXAMPLE_GROUPS = ('description', 'context', 'describe') + PENDING_EXAMPLE_GROUPS + FOCUSED_EXAMPLE_GROUPS + SHARED_EXAMPLE_GROUPS
     FOCUSED_EXAMPLE = ('fit', )
     PENDING_EXAMPLE = ('_it', )
@@ -46,6 +47,8 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
         if name in self.FOCUSED:
             self.has_focused_examples = True
 
+        if name in self.INCLUDED_EXAMPLE_GROUPS:
+            return self._get_shared_example_group(node)
         if name in self.EXAMPLE_GROUPS:
             return self._transform_to_example_group(node, name)
         if name in self.EXAMPLES:
@@ -142,6 +145,27 @@ class TransformToSpecsNodeTransformer(ast.NodeTransformer):
                 args=self._generate_argument('self'),
                 body=node.body,
                 decorator_list=[]
+            ),
+            node
+        )
+
+    def _get_shared_example_group(self, node):
+        context_expr = self._context_expr_for(node)
+        example_name = self._human_readable_context_expr(context_expr)
+
+        return ast.copy_location(
+            ast.ClassDef(
+                name=self._prefix_with_sequence(example_name),
+                bases=[],
+                keywords=[],
+                body=node.body,
+                decorator_list=[
+                    self._set_attribute('_example_group', True),
+                    self._set_attribute('_example_name', example_name),
+                    self._set_attribute('_tags', self._tags_from(context_expr, 'context')),
+                    self._set_attribute('_pending', False),
+                    self._set_attribute('_shared', False)
+                ]
             ),
             node
         )

--- a/spec/example_collector_spec.py
+++ b/spec/example_collector_spec.py
@@ -153,6 +153,15 @@ with description(ExampleCollector):
             expect(examples[1]).to(have_length(1))
             expect(examples[1].examples[0]).to(be_a(example_group.ExampleGroup))
 
+        with it('inserts the examples of the shared context'):
+            module = _load_module(INCLUDED_CONTEXT_PATH)
+
+            examples = loader.Loader().load_examples_from(module)
+
+            expect(examples[1]).to(have_length(1))
+            included_context = examples[1].examples[0]
+            expect(example_names(included_context.examples)).to(equal(['it shared example', 'it added example']))
+
     with context('when loading with relative import'):
         with it('loads module and perform relative import'):
             module = _load_module(WITH_RELATIVE_IMPORT_PATH)

--- a/spec/example_collector_spec.py
+++ b/spec/example_collector_spec.py
@@ -17,6 +17,10 @@ def spec_abspath(name):
     return os.path.join(os.path.dirname(__file__), 'fixtures', name)
 
 
+def example_names(examples):
+    return [example.name for example in examples]
+
+
 IRRELEVANT_PATH = spec_abspath('without_inner_contexts.py')
 PENDING_DECORATOR_PATH = spec_abspath('with_pending_decorator.py')
 PENDING_DECORATOR_AS_ROOT_PATH = spec_abspath('with_pending_decorator_as_root.py')
@@ -52,7 +56,7 @@ with description(ExampleCollector):
             examples = loader.Loader().load_examples_from(module)
 
             expect(examples).to(have_length(1))
-            expect([example.name for example in examples[0].examples]).to(equal(['it first example', 'it second example', 'it third example']))
+            expect(example_names(examples[0].examples)).to(equal(['it first example', 'it second example', 'it third example']))
 
         with it('places examples together and groups at the end'):
             module = _load_module(spec_abspath('with_inner_contexts.py'))
@@ -60,7 +64,7 @@ with description(ExampleCollector):
             examples = loader.Loader().load_examples_from(module)
 
             expect(examples).to(have_length(1))
-            expect([example.name for example in examples[0].examples]).to(equal(['it first example', 'it second example', 'it third example', '#inner_context']))
+            expect(example_names(examples[0].examples)).to(equal(['it first example', 'it second example', 'it third example', '#inner_context']))
 
     with context('when reading tags'):
         with it('reads tags from description parameters'):

--- a/spec/example_collector_spec.py
+++ b/spec/example_collector_spec.py
@@ -24,6 +24,7 @@ WITH_RELATIVE_IMPORT_PATH = spec_abspath('with_relative_import.py')
 WITH_TAGS_PATH = spec_abspath('with_tags.py')
 WITH_FOCUS_PATH = spec_abspath('with_focus.py')
 SHARED_CONTEXT_PATH = spec_abspath('with_shared_context.py')
+INCLUDED_CONTEXT_PATH = spec_abspath('with_included_context.py')
 
 
 def _load_module(path):
@@ -138,6 +139,15 @@ with description(ExampleCollector):
 
             expect(examples).to(have_length(1))
             expect(examples[0]).to(be_a(example_group.SharedExampleGroup))
+
+    with context('when a included context is loaded'):
+        with it('insert a normal example group instead'):
+            module = _load_module(INCLUDED_CONTEXT_PATH)
+
+            examples = loader.Loader().load_examples_from(module)
+
+            expect(examples[1]).to(have_length(1))
+            expect(examples[1].examples[0]).to(be_a(example_group.ExampleGroup))
 
     with context('when loading with relative import'):
         with it('loads module and perform relative import'):

--- a/spec/example_collector_spec.py
+++ b/spec/example_collector_spec.py
@@ -23,6 +23,7 @@ PENDING_DECORATOR_AS_ROOT_PATH = spec_abspath('with_pending_decorator_as_root.py
 WITH_RELATIVE_IMPORT_PATH = spec_abspath('with_relative_import.py')
 WITH_TAGS_PATH = spec_abspath('with_tags.py')
 WITH_FOCUS_PATH = spec_abspath('with_focus.py')
+SHARED_CONTEXT_PATH = spec_abspath('with_shared_context.py')
 
 
 def _load_module(path):
@@ -128,6 +129,15 @@ with description(ExampleCollector):
             expect(examples_in_root[0]).to(be_a(example.PendingExample))
             expect(examples_in_root[1]).to(be_a(example_group.PendingExampleGroup))
             expect(examples_in_root[1].examples[0]).to(be_a(example.PendingExample))
+
+    with context('when a shared context is loaded'):
+        with it('mark context as shared'):
+            module = _load_module(SHARED_CONTEXT_PATH)
+
+            examples = loader.Loader().load_examples_from(module)
+
+            expect(examples).to(have_length(1))
+            expect(examples[0]).to(be_a(example_group.SharedExampleGroup))
 
     with context('when loading with relative import'):
         with it('loads module and perform relative import'):

--- a/spec/fixtures/with_included_context.py
+++ b/spec/fixtures/with_included_context.py
@@ -1,12 +1,13 @@
-from mamba import shared_context, included_context, describe, it, context
+from mamba import shared_context, included_context, describe, it
 
 SHARED_CONTEXT = 'Shared Context'
 
 with shared_context(SHARED_CONTEXT):
-    with it('first shared'):
+    with it('shared example'):
         pass
 
 
 with describe('Real tests'):
     with included_context(SHARED_CONTEXT):
-        pass
+        with it('added example'):
+            pass

--- a/spec/fixtures/with_included_context.py
+++ b/spec/fixtures/with_included_context.py
@@ -1,0 +1,12 @@
+from mamba import shared_context, included_context, describe, it, context
+
+SHARED_CONTEXT = 'Shared Context'
+
+with shared_context(SHARED_CONTEXT):
+    with it('first shared'):
+        pass
+
+
+with describe('Real tests'):
+    with included_context(SHARED_CONTEXT):
+        pass

--- a/spec/fixtures/with_shared_context.py
+++ b/spec/fixtures/with_shared_context.py
@@ -1,0 +1,5 @@
+from mamba import shared_context, it
+
+with shared_context('Shared Context'):
+    with it('example'):
+        pass

--- a/spec/object_mother.py
+++ b/spec/object_mother.py
@@ -1,4 +1,4 @@
-from mamba.example_group import ExampleGroup, PendingExampleGroup
+from mamba.example_group import ExampleGroup, PendingExampleGroup, SharedExampleGroup
 from mamba.example import Example, PendingExample
 
 IRRELEVANT_DESCRIPTION = 'any description'
@@ -10,6 +10,10 @@ def an_example_group(description=IRRELEVANT_DESCRIPTION):
 
 def a_pending_example_group(description=IRRELEVANT_DESCRIPTION):
     return PendingExampleGroup(IRRELEVANT_DESCRIPTION)
+
+
+def a_shared_example_group(description=IRRELEVANT_DESCRIPTION):
+    return SharedExampleGroup(IRRELEVANT_DESCRIPTION)
 
 
 def an_example():

--- a/spec/shared_example_group_spec.py
+++ b/spec/shared_example_group_spec.py
@@ -1,0 +1,29 @@
+from mamba import description, before, context, it
+from expects import expect, be_false
+from doublex_expects import have_been_called_with
+from doublex import Spy
+
+from spec.object_mother import *
+
+from mamba import reporter, runnable
+from mamba.example_group import SharedExampleGroup
+
+
+with description(SharedExampleGroup) as self:
+
+    with before.each:
+        self.example_group = a_shared_example_group()
+        self.reporter = Spy(reporter.Reporter)
+        self.example = an_example()
+
+    with context('when run'):
+        with before.each:
+            self.example_group.append(self.example)
+
+            self.example_group.execute(self.reporter, runnable.ExecutionContext())
+
+        with it('not runs its children'):
+            expect(self.example_group.examples[0].was_run).to(be_false)
+
+        with it('does not notify that an example group was started'):
+            expect(self.reporter.example_group_started).not_to(have_been_called_with(self.example_group))


### PR DESCRIPTION
I added two new example group contexts `shared_context` and `included_context`.

Any `shared_context` will not be executed on its own but will be inserted in any place where you use the context `included_context` **with the same description** . 

Example:
```python
with shared_context('Request tests'):
    with context('When the request succeeds'):
        with before.each:
            # Mocking success
        with it('returns HTTP Status Code 200'):
            ...
    with context('When the request fails'):
        ...

with describe('GET /api/important_data'):
    with before.all:
        # Some endpoint-specific preparations
    with included_context('Request tests'):
        pass

with describe('POST /api/dangerous'):
     with before.all:
        # Some endpoint-specific preparations
     with included_context('Request tests'):
        with it('additional security test'):
            pass
```

As demonstrated by the (maybe too simple?) tests, any examples defined inside the `included_context` will be added to those of the inserted shared context.

I didn't add any special support for several hooks or anything, since it shouldn't be necessary... with the current architecture of mamba, any hook defined inside `included_context` will take precedence over any hook defined in the inserted `shared_context`.
If you want to combine hooks of the same kind (two `before.each`, two `after.all`), you can just wrap the included context in another context that defines the additional hooks.


This will resolve Issue #90 (which I submitted myself some months ago)