### PR TITLE
Add pending formatter

### DIFF
--- a/mamba/application_factory.py
+++ b/mamba/application_factory.py
@@ -44,7 +44,8 @@ class ApplicationFactory(object):
         runner = runners.BaseRunner(self._example_collector(),
                                     self._loader(),
                                     self._reporter(),
-                                    self.settings.tags)
+                                    self.settings.tags,
+                                    self.settings.format)
 
         if self.settings.enable_code_coverage:
             runner = \
@@ -67,6 +68,8 @@ class ApplicationFactory(object):
             return formatters.ProgressFormatter(self.settings)
         if self.settings.format == 'documentation':
             return formatters.DocumentationFormatter(self.settings)
+        if self.settings.format == 'pending':
+            return formatters.PendingFormatter(self.settings)
 
         return self._custom_formatter()
 

--- a/mamba/formatters.py
+++ b/mamba/formatters.py
@@ -185,3 +185,33 @@ class ProgressFormatter(DocumentationFormatter):
         puts()
         puts()
         super(ProgressFormatter, self).summary(duration, example_count, failed_count, pending_count)
+
+
+class PendingFormatter(DocumentationFormatter):
+
+    def example_passed(self, example):
+        pass
+
+    def example_failed(self, example):
+        pass
+
+    def example_group_started(self, example_group):
+        if example_group.parent is None:
+            puts()
+        self._format_example_group(example_group, 'white')
+
+    def example_group_pending(self, example_group):
+        self._format_example_group(example_group, 'yellow')
+
+    def example_group_finished(self, example_group):
+        pass
+
+    def summary(self, duration, example_count, failed_count, pending_count):
+        duration = self._format_duration(duration)
+        if failed_count != 0:
+            puts(self._color('red', "%d examples failed of %d ran in %s" % (failed_count, example_count, duration)))
+        elif pending_count != 0:
+            puts()
+            puts(self._color('yellow', "%d examples ran (%d pending) in %s" % (example_count, pending_count, duration)))
+        else:
+            puts(self._color('green', "%d examples ran in %s" % (example_count, duration)))

--- a/mamba/runners.py
+++ b/mamba/runners.py
@@ -16,12 +16,13 @@ class Runner(object):
 
 class BaseRunner(Runner):
 
-    def __init__(self, example_collector, loader, reporter, tags):
+    def __init__(self, example_collector, loader, reporter, tags, formatter):
         self.example_collector = example_collector
         self.loader = loader
         self.reporter = reporter
         self._has_failed_examples = False
         self.tags = tags
+        self.formatter = formatter
 
     def run(self):
         self.reporter.start()
@@ -30,6 +31,9 @@ class BaseRunner(Runner):
 
         if self._any_module_has_focused_examples(modules):
             self.tags = ['focus']
+
+        if self.formatter == 'pending':
+            self.tags = ['pending']
 
         for module in modules:
             self._run_examples_in(module)


### PR DESCRIPTION
Adds new formatter: ```mamba -f pending $SPECS_PATH```

It displays every pending spec with its description as it does when focused specs are displayed.