### PR TITLE
Improve execution context binding of helper methods

### DIFF
--- a/mamba/example_group.py
+++ b/mamba/example_group.py
@@ -2,7 +2,6 @@
 
 import copy
 from datetime import datetime
-from functools import partial
 
 from mamba import runnable
 from mamba.example import PendingExample
@@ -62,7 +61,7 @@ class ExampleGroup(runnable.Runnable):
         for name, method in self.helpers.items():
             setattr(execution_context,
                     name,
-                    partial(method, execution_context))
+                    method.__get__(execution_context))
 
     def execute_hook(self, hook, execution_context):
         if hook.endswith('_all') and not self.hooks.get(hook):

--- a/mamba/example_group.py
+++ b/mamba/example_group.py
@@ -33,12 +33,13 @@ class ExampleGroup(runnable.Runnable):
 
         self._start(reporter)
         try:
-            self._bind_helpers_to(execution_context)
             self.execute_hook('before_all', execution_context)
 
             for example in self:
+                example_execution_context = copy.copy(execution_context)
+                self._bind_helpers_to(example_execution_context)
                 example.execute(reporter,
-                                copy.copy(execution_context),
+                                example_execution_context,
                                 tags=tags)
 
             self.execute_hook('after_all', execution_context)

--- a/mamba/loader.py
+++ b/mamba/loader.py
@@ -39,8 +39,8 @@ class Loader(object):
     def _add_hooks_examples_and_nested_example_groups_to(self, klass, example_group):
         self._load_hooks(klass, example_group)
         self._load_examples(klass, example_group)
-        self._load_nested_example_groups(klass, example_group)
         self._load_helper_methods(klass, example_group)
+        self._load_nested_example_groups(klass, example_group)
 
     def _load_hooks(self, klass, example_group):
         for hook in self._hooks_in(klass):
@@ -85,6 +85,7 @@ class Loader(object):
             else:
                 nested_example_group = self._create_example_group(nested)
 
+            nested_example_group.helpers = dict(example_group.helpers)
             self._add_hooks_examples_and_nested_example_groups_to(nested, nested_example_group)
             example_group.append(nested_example_group)
 

--- a/spec/refactoring_goodies_spec.py
+++ b/spec/refactoring_goodies_spec.py
@@ -16,3 +16,47 @@ with description('Refactoring goodies') as self:
 
         with it('uses methods defined inside its parent'):
             expect(self.a_method()).to(equal(RETURN_VALUE))
+
+    with describe('Execution context of methods'):
+        with context('When the value is defined in a before all hook of the same context'):
+
+            def method_with_context(self):
+                return self.context_value
+
+            with before.all:
+                self.context_value = RETURN_VALUE
+
+            with it('returns the value defined in the before all hook'):
+                expect(self.method_with_context()).to(equal(RETURN_VALUE))
+
+        with context('When the value is defined in a before all hook of a nested context'):
+
+            def method_with_context(self):
+                return self.context_value
+
+            with context('nested'):
+                with before.all:
+                    self.context_value = RETURN_VALUE
+
+                with it('returns the value defined in the before all hook'):
+                    expect(self.method_with_context()).to(equal(RETURN_VALUE))
+
+        with context('When the value is defined in a before each hook of the same context'):
+
+            def method_with_context(self):
+                return self.context_value
+
+            with before.each:
+                self.context_value = RETURN_VALUE
+
+            with it('returns the value defined in the before each hook'):
+                expect(self.method_with_context()).to(equal(RETURN_VALUE))
+
+        with context('When the value is defined in the example itself'):
+
+            def method_with_context(self):
+                return self.context_value
+
+            with it('returns the value defined in the before each hook'):
+                self.context_value = RETURN_VALUE
+                expect(self.method_with_context()).to(equal(RETURN_VALUE))


### PR DESCRIPTION
I improved the binding of execution contexts for helper methods.

### Why?
When a helper methods is defined in an example group it would be **permanently** bound to that particular execution context at that time. When creating a fresh copy of the execution context for nested examples/example groups, that reference would not be updated**, which would result in strange inconsistencies like:

```python
with context('Context'):
    def helper(self):
        return self.value + 1

    with it('example'):
        self.value = 3
        expect(self.helper()).to(equal(4))  # Raises NameError instead
```

### My solution
1. Bind helper methods after (and not before) copying the context
2. Always Inherit the helper method map from the parent context before adding own helper methods to it, so all methods can be bound the right current execution context.


** This happens because only a shallow copy of the execution context is made - but since the method was not "properly" bound to the instance, even if a deep copy was made (which would have a lot of other unseen side-effects), nothing would change. I took the freedom to "properly" bind the method instead of just partially applying it, it doesn't change anything, but it seems like the better and more official way to do things.