### PR TITLE
Remove requirements.txt file from MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.md requirements.txt
+include README.md


### PR DESCRIPTION
Since mamba uses pipenv, this should not be in the MANIFEST.in file