### PR TITLE
Fix multiple hook execution

### DIFF
--- a/mamba/example_group.py
+++ b/mamba/example_group.py
@@ -67,7 +67,7 @@ class ExampleGroup(runnable.Runnable):
         if hook.endswith('_all') and not self.hooks.get(hook):
             return
 
-        if self.parent is not None:
+        if not hook.endswith('_all') and self.parent is not None:
             self.parent.execute_hook(hook, execution_context)
 
         for registered in self.hooks.get(hook, []):


### PR DESCRIPTION
As stated in issue #105, before_all and after_all hooks were executed several times (but only if the nested context had a hook of the same kind).

This Pull Request should fix the issue.