### PR TITLE
Make progress formatter show its output immediately

### DIFF
--- a/mamba/formatters.py
+++ b/mamba/formatters.py
@@ -4,8 +4,13 @@ import sys
 import traceback
 import inspect
 
-from clint.textui import indent, puts, colored
+from clint.textui import indent, puts as textui_puts, colored
 
+
+def puts(*args, **kwargs):
+    textui_puts(*args, **kwargs)
+    sys.stdout.flush()
+    
 
 class Formatter(object):
 


### PR DESCRIPTION
When I use the default progress formatter my terminal will output nothing unless a newline is included.

Maybe that's a problem of my terminal settings or my OS (using MacOS).... but other test tools work just fine in that regard. (Ruby's RSpec for example).

I fixed that problem by wrapping the `puts` method of `clint` (which seems by the way not to be maintained at all anymore - the GitHub repository is archived) and always flushing the stdout stream