### PR TITLE
Add JUnit XML Formatter

### DIFF
--- a/mamba/application_factory.py
+++ b/mamba/application_factory.py
@@ -67,6 +67,8 @@ class ApplicationFactory(object):
             return formatters.ProgressFormatter(self.settings)
         if self.settings.format == 'documentation':
             return formatters.DocumentationFormatter(self.settings)
+        if self.settings.format == 'junit':
+            return formatters.JUnitFormatter(self.settings)
 
         return self._custom_formatter()
 

--- a/mamba/example.py
+++ b/mamba/example.py
@@ -8,9 +8,9 @@ from mamba import runnable
 class Example(runnable.Runnable):
 
     # TODO: Remove parent parameter, it's only used for testing purposes
-    def __init__(self, test, parent=None, tags=None):
+    def __init__(self, test, parent=None, tags=None, module=None):
         super(Example, self).__init__(parent=parent, tags=tags)
-
+        self.module = module
         self.test = test
         self.was_run = False
 
@@ -56,6 +56,14 @@ class Example(runnable.Runnable):
     @property
     def name(self):
         return self.test._example_name
+
+    @property
+    def file(self):
+        return self.module.__file__
+
+    @property
+    def classname(self):
+        return self.module.__name__.replace('/', '.')
 
 
 class PendingExample(Example):

--- a/mamba/formatters.py
+++ b/mamba/formatters.py
@@ -114,13 +114,12 @@ class DocumentationFormatter(Formatter):
         puts()
         with indent(2):
             for index, failed in enumerate(failed_examples):
-                puts('%d) %s' % (index + 1, self._format_full_example_name(failed)))
+                puts('%d) %s' % (index + 1, self.format_full_example_name(failed)))
                 with indent(3):
-                    puts(self._color('red', 'Failure/Error: %s' % self._format_failing_expectation(failed)))
-                    puts(self._color('red', self._format_traceback(failed)))
+                    puts(self._color('red', self.format_failure(failed)))
                     puts()
 
-    def _format_full_example_name(self, example):
+    def format_full_example_name(self, example):
         result = [example.name]
 
         current = example
@@ -130,6 +129,9 @@ class DocumentationFormatter(Formatter):
 
         result.reverse()
         return ' '.join(result)
+
+    def format_failure(self, failed):
+        return "Failure/Error: %s\n%s" % (self._format_failing_expectation(failed), self._format_traceback(failed))
 
     def _format_failing_expectation(self, example_):
         tb = self._traceback(example_)

--- a/mamba/loader.py
+++ b/mamba/loader.py
@@ -9,6 +9,7 @@ from mamba.infrastructure import is_python3
 
 class Loader(object):
     def load_examples_from(self, module):
+        self.module = module
         loaded = []
         example_groups = self._example_groups_for(module)
 
@@ -56,9 +57,9 @@ class Loader(object):
         for example in self._examples_in(klass):
             tags = example._tags
             if self._is_pending_example(example) or self._is_pending_example_group(example_group):
-                example_group.append(PendingExample(example, tags=tags))
+                example_group.append(PendingExample(example, tags=tags, module=self.module))
             else:
-                example_group.append(Example(example, tags=tags))
+                example_group.append(Example(example, tags=tags, module=self.module))
 
     def _examples_in(self, example_group):
         return [method for name, method in self._methods_for(example_group) if self._is_example(method)]


### PR DESCRIPTION
I added a JUnit xml formatter, which generates an XML file that can be read by CircleCI.

For now the content of the XML is output to stdout and thus can be redirected into a file with `>`...

Should I add something like an `--output`?