### PR TITLE
Avoid linter warning: before and after has not method each

### DIFF
--- a/mamba/__init__.py
+++ b/mamba/__init__.py
@@ -1,3 +1,6 @@
+import contextlib
+
+
 __version__ = '0.10'
 
 
@@ -57,9 +60,21 @@ def included_context(message):
     pass
 
 
+@contextlib.contextmanager
 def before():
     pass
 
 
+@contextlib.contextmanager
+def before_all():
+    pass
+
+
+@contextlib.contextmanager
 def after():
+    pass
+
+
+@contextlib.contextmanager
+def after_all():
     pass


### PR DESCRIPTION
Some python linters marks `with after.each` or `before.each` blocks as warning because method has not `each` property. They are defined as functions at `__init__.py`, so I added a contextmanganer decorator for `before, before_all, after, after_all` to avoid this warnings.