### PR TITLE
Fix hooks: double *alls and reversed teardown ordering.

### DIFF
--- a/mamba/example_group.py
+++ b/mamba/example_group.py
@@ -67,7 +67,7 @@ class ExampleGroup(runnable.Runnable):
         if hook.endswith('_all') and not self.hooks.get(hook):
             return
 
-        if self.parent is not None:
+        if self.parent is not None and hook.startswith("before") and not hook.endswith("_all"):
             self.parent.execute_hook(hook, execution_context)
 
         for registered in self.hooks.get(hook, []):
@@ -78,6 +78,10 @@ class ExampleGroup(runnable.Runnable):
                     registered(execution_context)
             except Exception:
                 self.fail()
+
+        if self.parent is not None and hook.startswith("after") and not hook.endswith("_all"):
+            self.parent.execute_hook(hook, execution_context)
+
 
     def _finish(self, reporter):
         self.elapsed_time = datetime.utcnow() - self._begin

--- a/spec/hooks_spec.py
+++ b/spec/hooks_spec.py
@@ -95,3 +95,31 @@ with description('Hooks') as self:
             self.parent.execute(self.reporter, self.execution_context)
 
             expect(self.execution_context.calls).to(equal(['before_all_parent', 'before_each_parent', 'before_each_child', 'example']))
+
+        with it('should act like a stack, when parent and child groups have all possible hooks'):
+            self.parent.hooks['before_all'] = [lambda ctx: ctx.calls.append('before_all_parent')]
+            self.parent.hooks['after_all'] = [lambda ctx: ctx.calls.append('after_all_parent')]
+            self.parent.hooks['before_each'] = [lambda ctx: ctx.calls.append('before_each_parent')]
+            self.parent.hooks['after_each'] = [lambda ctx: ctx.calls.append('after_each_parent')]
+
+            child = an_example_group()
+            child.hooks['before_all'] = [lambda ctx: ctx.calls.append('before_all_child')]
+            child.hooks['after_all'] = [lambda ctx: ctx.calls.append('after_all_child')]
+            child.hooks['before_each'] = [lambda ctx: ctx.calls.append('before_each_child')]
+            child.hooks['after_each'] = [lambda ctx: ctx.calls.append('after_each_child')]
+
+            child.append(Example(lambda ctx: ctx.calls.append('example')))
+            self.parent.append(child)
+
+            self.parent.execute(self.reporter, self.execution_context)
+
+            expect(self.execution_context.calls).to(equal([
+                'before_all_parent',
+                'before_all_child',
+                'before_each_parent',
+                'before_each_child',
+                'example',
+                'after_each_child',
+                'after_each_parent',
+                'after_all_child',
+                'after_all_parent']))


### PR DESCRIPTION
Fixes #130 