### PR TITLE
Don't run after_each for blocks that didn't get a chance to run before_each.

### DIFF
--- a/mamba/example.py
+++ b/mamba/example.py
@@ -22,12 +22,18 @@ class Example(runnable.Runnable):
         self._start(reporter)
 
         if self.error is None:
-            self.parent.execute_hook('before_each', execution_context)
+            try:
+                self.parent.execute_hook('before_each', execution_context)
+            except Exception:
+                self.fail()
 
         if self.error is None:
             self._execute_test(execution_context)
 
-        self.parent.execute_hook('after_each', execution_context)
+        try:
+            self.parent.execute_hook('after_each', execution_context)
+        except Exception:
+            self.fail()
 
         self._finish(reporter)
 


### PR DESCRIPTION
Fixes #52 

This PR is based on my other PR, #131 

Please let me know how to open this one. I can only open to master branch. I could merge both of my PRs and submit them as one patch if it's preferable. Otherwise, the diff contains changes from #131 as well and may be hard to read...

