### PR TITLE
Enable Python3.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
 python:
-  - "2.7"
   - "3.6"
+  - "3.7"
   - "3.8"
-  - "pypy"
+  - "3.8-dev"
+  - "nightly"
   - "pypy3"
 install:
   - pip install pipenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.6"
   - "3.8"
   - "pypy"
+  - "pypy3"
 install:
   - pip install pipenv
   - pipenv install --dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "2.7"
   - "3.6"
+  - "3.8"
   - "pypy"
 install:
   - pip install pipenv

--- a/mamba/nodetransformers.py
+++ b/mamba/nodetransformers.py
@@ -199,6 +199,7 @@ class TransformToSpecsPython3NodeTransformer(TransformToSpecsNodeTransformer):
 
     def _generate_argument(self, name):
         return ast.arguments(
+            posonlyargs=[],
             args=[ast.arg(arg=name, annotation=None)],
             vararg=None,
             kwonlyargs=[],


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes mamba to work on Python 3.8.

It also enables those platforms on CI

**Which issue(s) this PR fixes**:

Refs #144 

**Special notes for your reviewer**:
