### PR TITLE
Remove references to mock backport since mamba only supports Python 3

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,6 @@ name = "pypi"
 [dev-packages]
 expects = ">=0.8.0"
 doublex-expects = ">=0.7.0rc2"
-mock = ">=2.0.0"
 sphinx = ">=1.6.5"
 sphinx-autobuild = ">=0.7.1"
 e1839a8 = {editable = true,path = "."}

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(name='mamba',
       include_package_data=True,
       zip_safe=False,
       install_requires=['clint', 'coverage'],
-      test_require=['expect', 'doublex', 'doublex-expects', 'mock'],
+      test_require=['expect', 'doublex', 'doublex-expects'],
       entry_points={
           'console_scripts': [
               'mamba = mamba.cli:main'

--- a/spec/mock_patch_example_spec.py
+++ b/spec/mock_patch_example_spec.py
@@ -1,8 +1,5 @@
 from mamba import description, context, it
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 from expects import expect, be
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove references to mock backport since mamba only supports Python 3

**Special notes for your reviewer**:
I haven't touched `Pipfile.lock` because I am not familiar with the pipenv workflow.