### PR TITLE
fix: change junit 'time' field format, as it breaks some importers when parsing it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## Version 0.11.2
+
+* Fix time field format for JUnit formatter
+
 ## Version 0.11.1
 
 * Fix compatiblity issue with 3.8.4

--- a/mamba/__init__.py
+++ b/mamba/__init__.py
@@ -1,7 +1,7 @@
 import contextlib
 
 
-__version__ = '0.11.1'
+__version__ = '0.11.2'
 
 
 def description(message):

--- a/mamba/formatters.py
+++ b/mamba/formatters.py
@@ -231,7 +231,7 @@ class JUnitFormatter(DocumentationFormatter):
         self.suite.attrib['tests'] = str(example_count)
         self.suite.attrib['skipped'] = str(pending_count)
         self.suite.attrib['failures'] = str(failed_count)
-        self.suite.attrib['time'] = str(duration)
+        self.suite.attrib['time'] = '%f'  % (duration.total_seconds(), )
         ElementTree.ElementTree(self.suite).write(sys.stdout, encoding='unicode')
 
     def _dump_example(self, example, child=None):
@@ -239,7 +239,7 @@ class JUnitFormatter(DocumentationFormatter):
             'classname': example.classname,
             'name': self.format_full_example_name(example),
             'file': example.file,
-            'time': str(example.elapsed_time.total_seconds())
+            'time': '%f' % (example.elapsed_time.total_seconds(), )
         })
         if child is not None:
             testcase.append(child)


### PR DESCRIPTION
**What this PR does / why we need it**:

The 'time' field in the JUnit formatter was output as `0:00:00.693097'  instead of just plain seconds, like `0.693097`. JUnit consumers just taking it as a string worker, but if they tried to parse it as a float, it failed. 


**Special notes for your reviewer**:
